### PR TITLE
Add support for custom attributes (close #11)

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -9,6 +9,11 @@ use Fhaculty\Graph\Attribute\AttributeAware;
 class Loader
 {
     /**
+     * @var array
+     **/
+    private $attributeNamespaces = array();
+
+    /**
      * Loads a graph instance from the given GraphML contents.
      *
      * ```php
@@ -37,6 +42,11 @@ class Loader
     public function loadContents($contents)
     {
         return $this->loadXml(new SimpleXMLElement($contents));
+    }
+
+    public function registerAttributeNamespace($ns, $isPrefix)
+    {
+        $this->attributeNamespaces[$ns] = $isPrefix;
     }
 
     /**
@@ -110,6 +120,13 @@ class Loader
         foreach ($xml->data as $dataElem) {
             $key = $keys[(string)$dataElem['key']];
             $target->setAttribute($key['name'], $this->castAttribute((string)$dataElem, $key['type']));
+        }
+
+        foreach ($this->attributeNamespaces as $attributeNamespace => $isPrefix) {
+            foreach ($xml->attributes($attributeNamespace, $isPrefix) as $attribute => $attributeValue) {
+                $attributeName = $isPrefix ? $attributeNamespace . ':' . $attribute : $attribute;
+                $target->setAttribute($attributeName, $this->castAttribute((string) $attributeValue, ''));
+            }
         }
     }
 

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -4,6 +4,9 @@ use Graphp\GraphML\Loader;
 
 class LoaderTest extends TestCase
 {
+    /**
+     * @var Loader
+     */
     private $loader;
 
     public function setUp()
@@ -174,5 +177,63 @@ EOL;
 
         $this->assertEquals('n0', $vertex->getId());
         $this->assertEquals('yellow', $vertex->getAttribute('color'));
+    }
+
+    public function testCustomAttributesWithPrefix()
+    {
+        $data = <<<EOL
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"  
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns 
+                                graphml+xlink.xsd">
+  <graph edgedefault="directed">
+    <node id="n0" xlink:href="http://graphml.graphdrawing.org"/>
+    <node id="n1" />
+    <edge source="n0" target="n1" xlink:href="http://graphdrawing.org"/>
+  </graph>
+</graphml>
+EOL;
+        $this->loader = new Loader();
+        $this->loader->registerAttributeNamespace('xlink', true);
+        $graph = $this->loader->loadContents($data);
+
+        $vertex = $graph->getVertices()->getVertexFirst();
+
+        $this->assertEquals('n0', $vertex->getId());
+        $this->assertEquals('http://graphml.graphdrawing.org', $vertex->getAttribute('xlink:href'));
+
+        $edge = $graph->getEdges()->getEdgeFirst();
+        $this->assertEquals('http://graphdrawing.org', $edge->getAttribute('xlink:href'));
+    }
+
+    public function testCustomAttributesWithNamespace()
+    {
+        $data = <<<EOL
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"  
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns 
+                                graphml+xlink.xsd">
+  <graph edgedefault="directed">
+    <node id="n0" xlink:href="http://graphml.graphdrawing.org"/>
+    <node id="n1" />
+    <edge source="n0" target="n1" xlink:href="http://graphdrawing.org"/>
+  </graph>
+</graphml>
+EOL;
+        $this->loader = new Loader();
+        $this->loader->registerAttributeNamespace('http://www.w3.org/1999/xlink', false);
+        $graph = $this->loader->loadContents($data);
+
+        $vertex = $graph->getVertices()->getVertexFirst();
+
+        $this->assertEquals('n0', $vertex->getId());
+        $this->assertEquals('http://graphml.graphdrawing.org', $vertex->getAttribute('href'));
+
+        $edge = $graph->getEdges()->getEdgeFirst();
+        $this->assertEquals('http://graphdrawing.org', $edge->getAttribute('href'));
     }
 }


### PR DESCRIPTION
There are some limitations:

1. Same attribute names for one node from different namespaces would be overwritten (last wins)
1. No types are supported, value is always a string