### PR TITLE
Run tests on PHPUnit 9, on PHP 7.4 and add .gitattributes to exclude dev files from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,26 @@
 language: php
 
-php:
-# - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm # ignore errors, see below
-
 # lock distro so future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm-3.18
   allow_failures:
-    - php: hhvm
-
-sudo: false
+    - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
   - vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,12 @@
         "clue/graph": "~0.9.0|~0.8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {"Graphp\\GraphML\\": "src/"}
+    },
+    "autoload-dev": {
+        "psr-4": { "Graphp\\Tests\\GraphML\\": "tests/" }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+<phpunit bootstrap="vendor/autoload.php" 
+         colors="true" 
+         cacheResult="false">
     <testsuites>
         <testsuite name="GraphML Test Suite">
             <directory>./tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" 
-         colors="true" 
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
          cacheResult="false">
     <testsuites>
         <testsuite name="GraphML Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="GraphML Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Graphp\Tests\GraphML;
+
 use Fhaculty\Graph\Graph;
 use Graphp\GraphML\Exporter;
 
@@ -7,7 +9,10 @@ class ExporterTest extends TestCase
 {
     private $exporter;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpExporter()
     {
         $this->exporter = new Exporter();
     }
@@ -17,7 +22,7 @@ class ExporterTest extends TestCase
         $graph = new Graph();
 
         $output = $this->exporter->getOutput($graph);
-        $xml = new SimpleXMLElement($output);
+        $xml = new \SimpleXMLElement($output);
 
         $this->assertEquals(1, count($xml));
         $this->assertEquals(1, count($xml->graph));
@@ -33,7 +38,7 @@ class ExporterTest extends TestCase
         $v1->createEdge($v2);
 
         $output = $this->exporter->getOutput($graph);
-        $xml = new SimpleXMLElement($output);
+        $xml = new \SimpleXMLElement($output);
 
         $this->assertEquals(1, count($xml->graph->edge));
 
@@ -52,7 +57,7 @@ class ExporterTest extends TestCase
         $v1->createEdgeTo($v2);
 
         $output = $this->exporter->getOutput($graph);
-        $xml = new SimpleXMLElement($output);
+        $xml = new \SimpleXMLElement($output);
 
         $this->assertEquals(1, count($xml->graph->edge));
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Graphp\Tests\GraphML;
+
 use Fhaculty\Graph\Graph;
 use Graphp\GraphML\Exporter;
 use Graphp\GraphML\Loader;

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -1,12 +1,17 @@
 <?php
 
+namespace Graphp\Tests\GraphML;
+
 use Graphp\GraphML\Loader;
 
 class LoaderTest extends TestCase
 {
     private $loader;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpLoader()
     {
         $this->loader = new Loader();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,13 +1,12 @@
 <?php
 
+namespace Graphp\Tests\GraphML;
+
 use Fhaculty\Graph\Edge\Directed;
 use Fhaculty\Graph\Edge\Base as Edge;
 use Fhaculty\Graph\Graph;
 use Fhaculty\Graph\Vertex;
-use Fhaculty\Graph\Set\Vertices;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-
-(include_once __DIR__ . '/../vendor/autoload.php') OR die(PHP_EOL . 'ERROR: composer autoloader not found, run "composer install" or see README for instructions' . PHP_EOL);
 
 class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).